### PR TITLE
Add darkwake=1 to boot-args

### DIFF
--- a/configs/config-BCM94360NG.plist
+++ b/configs/config-BCM94360NG.plist
@@ -945,7 +945,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100 alcid=3</string>
+				<string>keepsyms=1 debug=0x100 darkwake=1 alcid=3</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>

--- a/configs/config-BCM94360NG.plist
+++ b/configs/config-BCM94360NG.plist
@@ -594,7 +594,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -626,7 +626,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -642,7 +642,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>

--- a/configs/config-DW1560.plist
+++ b/configs/config-DW1560.plist
@@ -945,7 +945,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100 alcid=3</string>
+				<string>keepsyms=1 debug=0x100 darkwake=1 alcid=3</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>

--- a/configs/config-DW1560.plist
+++ b/configs/config-DW1560.plist
@@ -594,7 +594,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -626,7 +626,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -642,7 +642,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>

--- a/configs/config-i3Alt-BCM94360NG.plist
+++ b/configs/config-i3Alt-BCM94360NG.plist
@@ -947,7 +947,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100 alcid=3</string>
+				<string>keepsyms=1 debug=0x100 darkwake=1 alcid=3</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>

--- a/configs/config-i3Alt-BCM94360NG.plist
+++ b/configs/config-i3Alt-BCM94360NG.plist
@@ -596,7 +596,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -628,7 +628,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -644,7 +644,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>

--- a/configs/config-i3Alt-DW1560.plist
+++ b/configs/config-i3Alt-DW1560.plist
@@ -947,7 +947,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100 alcid=3</string>
+				<string>keepsyms=1 debug=0x100 darkwake=1 alcid=3</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>

--- a/configs/config-i3Alt-DW1560.plist
+++ b/configs/config-i3Alt-DW1560.plist
@@ -596,7 +596,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -628,7 +628,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>
@@ -644,7 +644,7 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>MinKernel</key>
 				<string></string>
 				<key>ExecutablePath</key>

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,8 @@ If updating from coreboot 4.11.2 to 4.12:
     - Sometimes it can be cleared by clicking/dragging randomly. Mostly succesful with clicking the lower portion of the trackpad. Sometimes a restart is required.
   - Most DRM does not work. This means no Apple TV shows, Hulu, Netflix (in Safari), Amazon Prime streaming, etc.
       - DRM simply does not work on an iGPU only Hackintosh 
-  - Wake on lid open (you have to press a key to wake)
+  - ~~Wake on lid open (you have to press a key to wake)~~
+    - Fixed by adding darkwake=1 to boot-args (included in latest config.plist)
   
 ### To Do:  
   - Try to move keyboard backlight control modifications from DSDT to SSDT for easier firmware upgrades


### PR DESCRIPTION
- Fixes lid wake not working by adding darkwake=1 to boot-args
- Also removed a few unnecessary kexts from loading from VoodooPS2Controller